### PR TITLE
support for bundles of type 'reference' (#5)

### DIFF
--- a/cmd/bundle/create.go
+++ b/cmd/bundle/create.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"arlon.io/arlon/pkg/common"
 	"context"
 	"fmt"
 	"github.com/spf13/cobra"
@@ -84,8 +85,8 @@ func createBundle(config *restclient.Config, ns string, bundleName string, fromF
 		secr.Data["data"] = data
 	} else if repoUrl != "" {
 		secr.Labels["bundle-type"] = "reference"
-		secr.ObjectMeta.Annotations["arlon.io/repo-url"] = repoUrl
-		secr.ObjectMeta.Annotations["arlon.io/repo-path"] = repoPath
+		secr.ObjectMeta.Annotations[common.RepoUrlAnnotationKey] = repoUrl
+		secr.ObjectMeta.Annotations[common.RepoPathAnnotationKey] = repoPath
 	} else {
 		return fmt.Errorf("the bundle must be created from a file or repo URL")
 	}

--- a/cmd/bundle/create.go
+++ b/cmd/bundle/create.go
@@ -39,7 +39,7 @@ func createBundleCommand() *cobra.Command {
 	clientConfig = cli.AddKubectlFlagsToCmd(command)
 	command.Flags().StringVar(&ns, "ns", "arlon", "the arlon namespace")
 	command.Flags().StringVar(&fromFile, "from-file", "", "create inline bundle from this file")
-	command.Flags().StringVar(&repoUrl, "from-repo", "", "create a reference bundle from this repo URL")
+	command.Flags().StringVar(&repoUrl, "repo-url", "", "create a reference bundle from this repo URL")
 	command.Flags().StringVar(&repoPath, "repo-path", "", "optional path in repo specified by --from-repo")
 	command.Flags().StringVar(&desc, "desc", "", "description")
 	command.Flags().StringVar(&tags, "tags", "", "comma separated list of tags")
@@ -72,6 +72,9 @@ func createBundle(config *restclient.Config, ns string, bundleName string, fromF
 			"tags": []byte(tags),
 		},
 	}
+	if fromFile != "" && repoUrl != "" {
+		return fmt.Errorf("file and repo cannot both be specified")
+	}
 	if fromFile != "" {
 		data, err := os.ReadFile(fromFile)
 		if err != nil {
@@ -81,8 +84,8 @@ func createBundle(config *restclient.Config, ns string, bundleName string, fromF
 		secr.Data["data"] = data
 	} else if repoUrl != "" {
 		secr.Labels["bundle-type"] = "reference"
-		secr.ObjectMeta.Annotations["repo-url"] = repoUrl
-		secr.ObjectMeta.Annotations["repo-path"] = repoPath
+		secr.ObjectMeta.Annotations["arlon.io/repo-url"] = repoUrl
+		secr.ObjectMeta.Annotations["arlon.io/repo-path"] = repoPath
 	} else {
 		return fmt.Errorf("the bundle must be created from a file or repo URL")
 	}

--- a/cmd/bundle/list.go
+++ b/cmd/bundle/list.go
@@ -51,15 +51,21 @@ func listBundles(config *restclient.Config, ns string) error {
 		return nil
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintf(w, "NAME\tTYPE\tTAGS\tDESCRIPTION\n")
+	_, _ = fmt.Fprintf(w, "NAME\tTYPE\tTAGS\tREPO-URL\tREPO-PATH\tDESCRIPTION\n")
 	for _, secret := range secrets.Items {
 		bundleType := secret.Labels["bundle-type"]
 		if bundleType == "" {
 			bundleType = "(undefined)"
 		}
+		repoUrl := secret.Annotations["arlon.io/repo-url"]
+		repoPath := secret.Annotations["arlon.io/repo-path"]
+		if bundleType != "reference" {
+			repoUrl = "(N/A)"
+			repoPath = "(N/A)"
+		}
 		tags := string(secret.Data["tags"])
 		desc := string(secret.Data["description"])
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", secret.Name, bundleType, tags, desc)
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", secret.Name, bundleType, tags, repoUrl, repoPath, desc)
 	}
 	_ = w.Flush()
 	return nil

--- a/cmd/bundle/list.go
+++ b/cmd/bundle/list.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"arlon.io/arlon/pkg/common"
 	"context"
 	"fmt"
 	"github.com/spf13/cobra"
@@ -57,8 +58,8 @@ func listBundles(config *restclient.Config, ns string) error {
 		if bundleType == "" {
 			bundleType = "(undefined)"
 		}
-		repoUrl := secret.Annotations["arlon.io/repo-url"]
-		repoPath := secret.Annotations["arlon.io/repo-path"]
+		repoUrl := secret.Annotations[common.RepoUrlAnnotationKey]
+		repoPath := secret.Annotations[common.RepoPathAnnotationKey]
 		if bundleType != "reference" {
 			repoUrl = "(N/A)"
 			repoPath = "(N/A)"

--- a/pkg/cluster/git.go
+++ b/pkg/cluster/git.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"arlon.io/arlon/pkg/common"
 	"arlon.io/arlon/pkg/gitutils"
 	"arlon.io/arlon/pkg/log"
 	"bytes"
@@ -211,7 +212,7 @@ func getBundles(
 	log := log.GetLogger()
 	bundleList := profileConfigMap.Data["bundles"]
 	if bundleList == "" {
-		return
+		return nil, fmt.Errorf("profile has no bundles")
 	}
 	bundleItems := strings.Split(bundleList, ",")
 	for _, bundleName := range bundleItems {
@@ -222,8 +223,8 @@ func getBundles(
 		bundles = append(bundles, bundle{
 			name: bundleName,
 			data: secr.Data["data"],
-			repoUrl: string(secr.Annotations["arlon.io/repo-url"]),
-			repoPath: string(secr.Annotations["arlon.io/repo-path"]),
+			repoUrl: string(secr.Annotations[common.RepoUrlAnnotationKey]),
+			repoPath: string(secr.Annotations[common.RepoPathAnnotationKey]),
 		})
 		log.V(1).Info("adding bundle", "bundleName", bundleName)
 	}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,0 +1,6 @@
+package common
+
+const (
+	RepoUrlAnnotationKey = "arlon.io/repo-url"
+	RepoPathAnnotationKey = "arlon.io/repo-path"
+)


### PR DESCRIPTION
Solves issue #5 
TODO: repo-url and repo-path are stored as annotations, but existing low-security properties like `tags` and `description` are stored in the secret's data portion. We should probably move those to annotations as well.